### PR TITLE
Integrate bootstrap3

### DIFF
--- a/amadaa/settings.py
+++ b/amadaa/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'bootstrap3',
     'ckeditor',
     'dashboard',
     'product',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.10.1
+django-bootstrap3==7.1.0
 django-ckeditor==5.1.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,6 @@
 {# base template for all others to inherit #}
 
+{% load bootstrap3 %}
 {% load static %}
 
 <!doctype html>


### PR DESCRIPTION
I have added integrate bootstrap3. The following URL should give an intro:
https://github.com/dyve/django-bootstrap3