### PR TITLE
Upgraded to django 1.10.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.1
+Django==1.10.2
 django-bootstrap-dynamic-formsets==0.4.5
 django-bootstrap3==7.1.0
 django-ckeditor==5.1.1


### PR DESCRIPTION
Django requirement has gone up to 1.10.2. Please perform pip install -r requirements. Then check that we haven't gone backwards...